### PR TITLE
[Finishes #130860843] added elasticsearch migration helper

### DIFF
--- a/migration/helper/es/index.js
+++ b/migration/helper/es/index.js
@@ -1,0 +1,145 @@
+
+const Bluebird = require('bluebird')
+const R        = require('ramda')
+
+// type alias Mapping =
+//   { String : { type : String } }
+
+// type alias ESResponse =
+//   { acknowledged : Boolean }
+
+// type alias Definition =
+//   { settings :
+//       index :
+//       { number_of_shards : Int
+//       , number_of_shards : Int
+//       , number_of_replicas : Int
+//       }
+//   }
+
+// type alias Factory =
+//   { up : ElasticsearchClient -> ( String, Definition ) -> Promise ESResponse
+//   , down : ElasticsearchClient -> String -> Promise ESResponse
+//   }
+
+// type alias ESMappingOption =
+//   { String : { String : a } }
+
+
+// getIndexList :: ElasticsearchClient -> Promise List String
+const getIndexList = (client) => {
+  return client.indices.stats({ index: '_all' })
+  .then(R.compose(
+    R.keys
+  , R.prop('indices')
+  ))
+}
+
+
+// hasIndex :: ElasticsearchClient -> String -> Promise Boolean
+const hasIndex = R.curry((client, name) => {
+  return getIndexList(client)
+  .then(R.contains(name))
+})
+
+
+// addIndex :: ElasticsearchClient -> ( String, Definition )
+//   -> Promise ESResponse | Promise null
+const addIndex = R.curry((client, name, definition) => {
+  return hasIndex(client)(name)
+  .then((has_index) => {
+    if (has_index) {
+      return null
+    }
+
+    return client.indices.create({
+      index : name
+    , body  : definition
+    })
+  })
+})
+
+
+// dropIndex ::
+//   ElasticsearchClient -> String -> Promise ESResponse | Promise null
+const dropIndex = R.curry((client, name) => {
+  return hasIndex(client)(name)
+  .then((has_index) => {
+    if (!has_index) {
+      return null
+    }
+
+    return client.indices.delete({
+      index: name
+    })
+  })
+})
+
+
+// addIndexFactory ::
+//   ElasticsearchClient -> ( String, Definition ) -> Promise Factory
+const addIndexFactory = R.curry((client, name, definition) => ({
+  up: (next) =>
+    addIndex(client)(name, definition)
+    .then(() => next())
+    .catch(next)
+
+, down: (next) =>
+    dropIndex(client)(name)
+    .then(() => next())
+    .catch(next)
+}))
+
+
+// addMappingsToIndex ::
+//   ElasticsearchClient -> ( String, String, Mapping, ESMappingOption )
+//   -> Promise ESResponse
+const _addMappingsToIndex = R.curry((client, index, type, mappings, options) =>
+  Bluebird.props({
+    index: index
+  , type: type
+  , body: { properties: mappings }
+  })
+  .then(R.ifElse(
+    () => R.is(Object, options)
+  , R.mergeWith(R.merge, R.__, { body: options })
+  , R.identity
+  ))
+  .then(client.indices.putMapping)
+)
+
+// getMappings :: ElasticsearchClient
+//   -> ( String -> String ) -> Promise Mapping | Promise null
+const getMappings = R.curry((client, index, type) => {
+  return client.indices.getMapping({ "index": index })
+  .then(R.pathOr(null, [index, 'mappings', type, 'properties']))
+  .catch(() => null)
+})
+
+// updateMappings :: ElasticsearchClient -> String
+//   -> ( String, Mapping, ESMappingOption ) -> Promise ESResponse
+const updateMappings = R.curry((client, index, type, mappings, options) => {
+  return addIndex(client)(index, null)
+  .then(() => _addMappingsToIndex(client)(index, type, mappings, options))
+})
+
+
+// canMigrate :: String -> String -> Promise Boolean
+const canMigrate = R.curry((client, index, type) => {
+  return getMappings(client)(index, type)
+  .then(R.compose(R.not, R.isNil))
+})
+
+
+module.exports  = (client) => ({
+  getIndexList    : getIndexList(client)
+, hasIndex        : hasIndex(client)
+, addIndex        : addIndex(client)
+, dropIndex       : dropIndex(client)
+
+, addIndexFactory : addIndexFactory(client)
+
+, getMappings     : getMappings(client)
+, updateMappings  : updateMappings(client)
+, canMigrate      : canMigrate(client)
+})


### PR DESCRIPTION
Add an elasticsearch migration helper in Kuss.

File path:
`<kuss-root>/migration/helper/es/index.js`

Usage :
`require('kuss/migration/helper/es')`
- I wrote this helper in node-api originally. it's copied here and stripped off of all semi-colons.
