### PR TITLE
[#131689197] RabbitMq Factory to use Promise

### DIFF
--- a/lib/rabbitmq/factory.js
+++ b/lib/rabbitmq/factory.js
@@ -1,8 +1,10 @@
 
 const R                        = require('ramda')
+const Bluebird                 = require('bluebird')
 const { Factory:QueueFactory } = require('./interface.js')
 
 
+// QueueLoader :: QueueConfig, String -> Promise Queue
 const QueueLoader = R.mapObjIndexed((queue_config, name) =>
   QueueFactory(R.assoc('name', name, queue_config))
 )
@@ -17,20 +19,24 @@ const GetQueue = R.curry((container, name) => R.ifElse(
 
 const Factory = (config) => {
 
-  const queue_container = QueueLoader(config)
-  const getQueue = GetQueue(queue_container)
+  Bluebird.resolve(QueueLoader(config.QUEUE))
 
-  return {
+  .then((queue_container) => {
+    GetQueue(queue_container)
+    .then((getQueue) => ({
+      send: (name, msg) =>
+        getQueue(name).get('send').then((send) => send(name, msg))
 
-    send: (name, msg, options = {}) =>
-      getQueue(name).send(options, msg)
+    , listen: (name, handler, options = {}) =>
+        getQueue(name).get('listen').then((listen) => listen(options, handler))
 
-  , listen: (name, handler, options = {}) =>
-      getQueue(name).listen(options, handler)
+    , addQueue: (name, conf) => {
+        queue_container[name] = QueueFactory(conf)
+        return queue_container
+      }
+    }))
+  })
 
-  , addQueue: (name, config) =>
-      queue_container[name] = QueueFactory(config)
-  }
 
 }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/131689197

Fix bugs when trying to send a rabbitmq event
- rabbitmq/factory returns an object { send:Fn, listen:Fn, addQueue:Fn } where send and listen aren't handling getQueue as a promise returning function.
- GetQueue was expecting a name as string but got object
