### PR TITLE
[#131689197] RabbitMq Factory to use Promise V1.1

### DIFF
--- a/lib/memory/index.js
+++ b/lib/memory/index.js
@@ -124,8 +124,6 @@ module.exports = function MemoryStore(data_set) {
   });
 
 
-  const getState = R.always(store)
-
   return {
     insert
     , upsert
@@ -136,7 +134,6 @@ module.exports = function MemoryStore(data_set) {
     , findOneBy
     , findById
     , findWhere
-    , getState
   };
 
 }

--- a/lib/memory/index.js
+++ b/lib/memory/index.js
@@ -123,6 +123,9 @@ module.exports = function MemoryStore(data_set) {
 
   });
 
+
+  const getState = R.always(store)
+
   return {
     insert
     , upsert
@@ -133,6 +136,7 @@ module.exports = function MemoryStore(data_set) {
     , findOneBy
     , findById
     , findWhere
+    , getState
   };
 
 }

--- a/lib/rabbitmq/factory.js
+++ b/lib/rabbitmq/factory.js
@@ -1,6 +1,5 @@
 
 const R                        = require('ramda')
-const Bluebird                 = require('bluebird')
 const { Factory:QueueFactory } = require('./interface.js')
 
 
@@ -24,14 +23,10 @@ const Factory = (config) => {
   return {
 
     send: (name, msg) =>
-      Bluebird.resolve(getQueue(name))
-      .get('send')
-      .then(R.apply(R.__, [name, msg]))
+      getQueue(name).then(q => q.send(name, msg))
 
   , listen: (name, handler, options = {}) =>
-      Bluebird.resolve(getQueue(name))
-      .get('listen')
-      .then(R.apply(R.__, [options, handler]))
+      getQueue(name).then(q => q.listen(options, handler))
 
   , addQueue: (name, queue_config) => {
       queue_container[name] = QueueFactory(queue_config)

--- a/lib/rabbitmq/factory.js
+++ b/lib/rabbitmq/factory.js
@@ -1,5 +1,6 @@
 
 const R                        = require('ramda')
+const Bluebird                 = require('bluebird')
 const { Factory:QueueFactory } = require('./interface.js')
 
 
@@ -8,7 +9,7 @@ const QueueLoader = R.mapObjIndexed((queue_config, name) =>
 )
 
 
-const GetQueue = R.curry((container, name) => R.ifElse(
+const GetQueue = R.curry((container, {name}) => R.ifElse(
   R.has(name)
 , R.prop(name)
 , () => { throw new Error(`Invalid Queue: ${name}`) }
@@ -22,14 +23,20 @@ const Factory = (config) => {
 
   return {
 
-    send: (name, msg, options = {}) =>
-      getQueue(name).send(options, msg)
+    send: (name, msg) =>
+      Bluebird.resolve(getQueue(name))
+      .get('send')
+      .then(R.apply(R.__, [name, msg]))
 
   , listen: (name, handler, options = {}) =>
-      getQueue(name).listen(options, handler)
+      Bluebird.resolve(getQueue(name))
+      .get('listen')
+      .then(R.apply(R.__, [options, handler]))
 
-  , addQueue: (name, config) =>
-      queue_container[name] = QueueFactory(config)
+  , addQueue: (name, queue_config) => {
+      queue_container[name] = QueueFactory(queue_config)
+      return queue_container
+    }
   }
 
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/131689197

Fix bugs when trying to send a rabbitmq event
- rabbitmq/factory returns an object { send:Fn, listen:Fn, addQueue:Fn } where send and listen aren't handling getQueue as a promise returning function.
- GetQueue was expecting a name as string but got object
