### PR TITLE
[#133559651] Add updateWhereEq function

### DIFF
--- a/lib/memory/index.js
+++ b/lib/memory/index.js
@@ -99,7 +99,7 @@ module.exports = function MemoryStore(data_set) {
   const updateWhereEq = R.curry((bucket, predicate, updates) =>
     getAll(bucket)
     .then(R.filter(R.whereEq(predicate)))
-    .each(function(row) {
+    .each(row => {
       store[bucket][row.id] = R.merge(store[bucket][row.id], updates)
     })
     .then(R.length)

--- a/lib/memory/index.js
+++ b/lib/memory/index.js
@@ -99,9 +99,8 @@ module.exports = function MemoryStore(data_set) {
   const updateWhereEq = R.curry((bucket, predicate, updates) =>
     getAll(bucket)
     .then(R.filter(R.whereEq(predicate)))
-    .map(row => {
+    .each(function(row) {
       store[bucket][row.id] = R.merge(store[bucket][row.id], updates)
-      return row
     })
     .then(R.length)
   )

--- a/lib/memory/index.js
+++ b/lib/memory/index.js
@@ -95,8 +95,8 @@ module.exports = function MemoryStore(data_set) {
   const getAll = R.compose(Bluebird.resolve, R.values, getBucket)
 
 
-  // updateWhere :: Bucket -> Predicate -> Updates -> Promise Int
-  const updateWhere = R.curry((bucket, predicate, updates) =>
+  // updateWhereEq :: Bucket -> Predicate -> Updates -> Promise Int
+  const updateWhereEq = R.curry((bucket, predicate, updates) =>
     getAll(bucket)
     .then(R.filter(R.whereEq(predicate)))
     .map(row => {
@@ -104,7 +104,7 @@ module.exports = function MemoryStore(data_set) {
       return row
     })
     .then(R.length)
-)
+  )
 
 
   /** @TODO Query Routing
@@ -141,7 +141,7 @@ module.exports = function MemoryStore(data_set) {
   return {
     insert
   , update
-  , updateWhere
+  , updateWhereEq
   , upsert
   , getById
   , getAll

--- a/lib/memory/index.js
+++ b/lib/memory/index.js
@@ -95,6 +95,18 @@ module.exports = function MemoryStore(data_set) {
   const getAll = R.compose(Bluebird.resolve, R.values, getBucket)
 
 
+  // updateWhere :: Bucket -> Predicate -> Updates -> Promise Int
+  const updateWhere = R.curry((bucket, predicate, updates) =>
+    getAll(bucket)
+    .then(R.filter(R.whereEq(predicate)))
+    .map(row => {
+      store[bucket][row.id] = R.merge(store[bucket][row.id], updates)
+      return row
+    })
+    .then(R.length)
+)
+
+
   /** @TODO Query Routing
    * const query = QueryRouter(config.query_route_file)(store)
    */
@@ -129,6 +141,7 @@ module.exports = function MemoryStore(data_set) {
   return {
     insert
   , update
+  , updateWhere
   , upsert
   , getById
   , getAll

--- a/lib/mysql/index.js
+++ b/lib/mysql/index.js
@@ -58,11 +58,12 @@ const update = R.curry((mysql, table, id, params) =>
 const _predicateToWhereEq = R.compose(
   R.join(' AND ')
 , R.values
-, R.mapObjIndexed(R.ifElse(R.equals(null)
-  , (value, key) => `${key} IS NULL`
-  , (value, key) => `${key} = ${value}`
-  )
-))
+, R.mapObjIndexed(R.cond([
+    [ R.equals(null), (value, key) => `${key} IS NULL` ]
+  , [ R.is(String), (value, key) => `${key} = '${value}'` ]
+  , [ R.T, (value, key) => `${key} = ${value}` ]
+  ]))
+)
 
 
 const updateWhereEq = R.curry((mysql, table, predicates, record) =>

--- a/lib/mysql/index.js
+++ b/lib/mysql/index.js
@@ -54,16 +54,19 @@ const update = R.curry((mysql, table, id, params) =>
 )
 
 
-// _predicatesToWhere :: Predicate -> String
-const _predicateToWhere = R.compose(
+// _predicatesToWhereEq :: Predicate -> String
+const _predicateToWhereEq = R.compose(
   R.join(' AND ')
 , R.values
-, R.mapObjIndexed((value, key) => `${key} = ${value}`)
-)
+, R.mapObjIndexed(R.ifElse(R.equals(null)
+  , (value, key) => `${key} IS NULL`
+  , (value, key) => `${key} = ${value}`
+  )
+))
 
 
-const updateWhere = R.curry((mysql, table, predicates, record) =>
-  Query.updateWhere(mysql, table, _predicateToWhere(predicates), [], record)
+const updateWhereEq = R.curry((mysql, table, predicates, record) =>
+  Query.updateWhere(mysql, table, _predicateToWhereEq(predicates), [], record)
 )
 
 
@@ -157,14 +160,14 @@ const findById = R.curry((mysql, table, projection, id) =>
 
 
 module.exports = (mysql) => ({
-  insert       : insert(mysql)
-, update       : update(mysql)
-, updateWhere  : updateWhere(mysql)
-, upsert       : upsert(mysql)
-, getAll       : getAll(mysql)
-, getById      : getById(mysql)
-, projectAll   : projectAll(mysql)
-, findBy       : findBy(mysql)
-, findOneBy    : findOneBy(mysql)
-, findById     : findById(mysql)
+  insert        : insert(mysql)
+, update        : update(mysql)
+, updateWhereEq : updateWhereEq(mysql)
+, upsert        : upsert(mysql)
+, getAll        : getAll(mysql)
+, getById       : getById(mysql)
+, projectAll    : projectAll(mysql)
+, findBy        : findBy(mysql)
+, findOneBy     : findOneBy(mysql)
+, findById      : findById(mysql)
 })

--- a/lib/mysql/index.js
+++ b/lib/mysql/index.js
@@ -54,6 +54,19 @@ const update = R.curry((mysql, table, id, params) =>
 )
 
 
+// _predicatesToWhere :: Predicate -> String
+const _predicateToWhere = R.compose(
+  R.join(' AND ')
+, R.values
+, R.mapObjIndexed((value, key) => `${key} = ${value}`)
+)
+
+
+const updateWhere = R.curry((mysql, table, predicates, record) =>
+  Query.updateWhere(mysql, table, _predicateToWhere(predicates), [], record)
+)
+
+
 const getIdForUpsert = R.curry((mysql, table, keys, params) =>
   Query.getWhereParams(
     mysql
@@ -135,6 +148,7 @@ const findById = R.curry((mysql, table, projection, id) =>
   findOneBy(mysql, table, projection, FIELD_ID, id)
 )
 
+
 /** @TODO Query Routing
  * const query = R.curry((mysql, table, query_name, params) =>
  *   QueryRouter(table, query).then(fn) => fn(mysql, params))
@@ -145,6 +159,7 @@ const findById = R.curry((mysql, table, projection, id) =>
 module.exports = (mysql) => ({
   insert       : insert(mysql)
 , update       : update(mysql)
+, updateWhere  : updateWhere(mysql)
 , upsert       : upsert(mysql)
 , getAll       : getAll(mysql)
 , getById      : getById(mysql)

--- a/test/lib/memory.spec.js
+++ b/test/lib/memory.spec.js
@@ -1,4 +1,7 @@
 /*eslint-env node, mocha*/
+/* eslint no-magic-numbers: 0 */
+/* eslint max-nested-callbacks: [ 'error', 5 ] */
+
 const { expect }  = require('chai');
 const MemoryStore = require('../../lib/memory');
 
@@ -31,6 +34,43 @@ describe('lib/memory-store.js', function() {
       .then((result) => {
         expect(result.foo).to.eql(data.foo)
         expect(result.boo).to.eql('hoo')
+      })
+    })
+  })
+
+
+  describe('::updateWhere', function() {
+
+    it('should update records that satisfy the predicate', function() {
+
+      const bucket    = 'test'
+      const data1     = { id : '1', foo: 'bar1', boo: 'fuck1' }
+      const data2     = { id : '2', foo: 'bar1', boo: 'fuck2' }
+      const data3     = { id : '3', foo: 'bar3', boo: 'fuck3' }
+      const state     = {
+        [bucket] : {
+          [data1.id] : data1
+        , [data2.id] : data2
+        , [data3.id] : data3
+        }
+      }
+      const tempStore = MemoryStore(state)
+
+      return tempStore.updateWhere(bucket)({ foo : 'bar1' })({ boo : 'hoo' })
+
+      .then(updated => {
+
+        expect(updated).to.eql(2)
+
+        expect(state[bucket][data1.id].id).to.eql(data1.id)
+        expect(state[bucket][data1.id].foo).to.eql(data1.foo)
+        expect(state[bucket][data1.id].boo).to.eql('hoo')
+
+        expect(state[bucket][data2.id].id).to.eql(data2.id)
+        expect(state[bucket][data2.id].foo).to.eql(data2.foo)
+        expect(state[bucket][data2.id].boo).to.eql('hoo')
+
+        expect(state[bucket][data3.id]).to.eql(data3)
       })
     })
   })

--- a/test/lib/memory.spec.js
+++ b/test/lib/memory.spec.js
@@ -39,7 +39,7 @@ describe('lib/memory-store.js', function() {
   })
 
 
-  describe('::updateWhere', function() {
+  describe('::updateWhereEq', function() {
 
     it('should update records that satisfy the predicate', function() {
 
@@ -56,7 +56,7 @@ describe('lib/memory-store.js', function() {
       }
       const tempStore = MemoryStore(state)
 
-      return tempStore.updateWhere(bucket)({ foo : 'bar1' })({ boo : 'hoo' })
+      return tempStore.updateWhereEq(bucket)({ foo : 'bar1' })({ boo : 'hoo' })
 
       .then(updated => {
 

--- a/test/lib/mysql/index.spec.js
+++ b/test/lib/mysql/index.spec.js
@@ -1,5 +1,6 @@
 /*eslint-env node, mocha*/
 /* eslint no-magic-numbers: 0 */
+/* eslint 'max-len': [ 'error', 100 ] */
 
 const { expect } = require('chai')
 
@@ -87,7 +88,8 @@ describe('lib/mysql', function() {
 
       const table     = 'test'
       const updates   = { foo: 'bar', bar: 'baz' }
-      const sql_regex = /^UPDATE `test` SET \? WHERE foo = 1 AND bar IS NULL .*/
+      const predicate = { foo : 1, bar : null, one : 'one' }
+      const sql_regex = /^UPDATE `test` SET \? WHERE foo = 1 AND bar IS NULL AND one = \'one\' .*/
 
       mysql.query = (actual_sql, actual_updates, cb) => {
         expect(actual_sql).to.match(sql_regex)
@@ -95,7 +97,7 @@ describe('lib/mysql', function() {
         cb(null, { affectedRows: 3 })
       }
 
-      return store.updateWhereEq(table, { foo : 1, bar : null }, updates)
+      return store.updateWhereEq(table)(predicate)(updates)
       .then(result => {
         expect(result).to.eql(3)
       })

--- a/test/lib/mysql/index.spec.js
+++ b/test/lib/mysql/index.spec.js
@@ -1,6 +1,7 @@
 /*eslint-env node, mocha*/
+/* eslint no-magic-numbers: 0 */
+
 const { expect } = require('chai')
-const R = require('ramda')
 
 const MySqlStore = require('../../../lib/mysql')
 
@@ -72,6 +73,37 @@ describe('lib/mysql', function() {
       return store.update(table, id, params).then((result) => {
 
         expect(result).to.eql(id)
+
+      })
+
+    })
+
+  })
+
+
+  describe('::updateWhere', function() {
+
+
+    it('should execute an updateWhere query on the given table', function() {
+
+      const table     = 'test'
+      const updates    = { foo: 'bar', bar: 'baz' }
+      const sql_regex = /^UPDATE `test` SET \? WHERE foo = 1 AND bar = buzz .*/
+
+      mysql.query = (actual_sql, actual_updates, cb) => {
+
+        expect(actual_sql).to.match(sql_regex)
+        expect(actual_updates).to.deep.equal([updates])
+
+        cb(null, { affectedRows: 3 })
+
+      }
+
+      return store.updateWhere(table, { foo : 1, bar : 'buzz' }, updates)
+
+      .then(result => {
+
+        expect(result).to.eql(3)
 
       })
 

--- a/test/lib/mysql/index.spec.js
+++ b/test/lib/mysql/index.spec.js
@@ -81,34 +81,25 @@ describe('lib/mysql', function() {
   })
 
 
-  describe('::updateWhere', function() {
+  describe('::updateWhereEq', function() {
 
-
-    it('should execute an updateWhere query on the given table', function() {
+    it('should execute an updateWhereEq query on the given table', function() {
 
       const table     = 'test'
-      const updates    = { foo: 'bar', bar: 'baz' }
-      const sql_regex = /^UPDATE `test` SET \? WHERE foo = 1 AND bar = buzz .*/
+      const updates   = { foo: 'bar', bar: 'baz' }
+      const sql_regex = /^UPDATE `test` SET \? WHERE foo = 1 AND bar IS NULL .*/
 
       mysql.query = (actual_sql, actual_updates, cb) => {
-
         expect(actual_sql).to.match(sql_regex)
         expect(actual_updates).to.deep.equal([updates])
-
         cb(null, { affectedRows: 3 })
-
       }
 
-      return store.updateWhere(table, { foo : 1, bar : 'buzz' }, updates)
-
+      return store.updateWhereEq(table, { foo : 1, bar : null }, updates)
       .then(result => {
-
         expect(result).to.eql(3)
-
       })
-
     })
-
   })
 
 


### PR DESCRIPTION
Added updateWhereEq to Mysql and Memory interfaces

**usage**
```javascript
const store = require('kuss/lib/mysql/index.js')
const table = 'test'

const predicate = {
  foo  : 'bar'
, buzz : null
, one  : 0
}

const updates = {
  buzz : 'boom'
, one : 1
}


store.updateWhereEq(table)(predicate)(updates)

.then(updated => `updated ${updated} records`)
```