### PR TITLE
Add a little clarity

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -27,21 +27,19 @@ function _addBackoff(factory) {
 
   factory.create = function __run() {
 
-    return originalCreateMethod().catch((e) =>
+    return originalCreateMethod().catch(function ___handleCreateError(e) {
 
-      new Bluebird(function ___backoffRunResolver(resolve, reject) {
-        const wait = backoff.next()
+      const wait = backoff.next()
 
-        debug(
-          '::_addBackoff - could not create resource - waiting %d ms - %s'
-        , wait
-        , e.message
-        )
+      debug(
+        '::_addBackoff - could not create resource - waiting %d ms - %s'
+      , wait
+      , e.message
+      )
 
-        setTimeout(() => reject(e), wait)
-      })
+      return Bluebird.delay(wait).throw(e)
 
-    )
+    })
 
   }
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -27,7 +27,7 @@ function _addBackoff(factory) {
 
   factory.create = function __run() {
 
-    return originalCreateMethod().catch(function ___handleCreateError(e) {
+    return originalCreateMethod().catch(function ___handleErrorInCreate(e) {
 
       const wait = backoff.next()
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -41,6 +41,14 @@ function _addBackoff(factory) {
 
     })
 
+    .then((resource) => {
+
+      backoff.reset()
+
+      return resource
+
+    })
+
   }
 
   return factory


### PR DESCRIPTION
- don’t use the `new Bluebird` syntax
- remove one level of callback depth
- use Bluebird.delay utility method
- name error handler for better stack traces.
- reset the back off algorithm upon successful resource allocation.