### PR TITLE
Make configuration consistent

### DIFF
--- a/express-couchdb.js
+++ b/express-couchdb.js
@@ -1,18 +1,25 @@
 
+const debug = require('debug')('kuss:express:couchdb')
 const R             = require('ramda')
 const onFinished    = require('on-finished')
 const PluginFactory = require('./lib/plugin-factory.js')
 const CouchDBPool   = require('./lib/couchdb/pool.js')
 
 
+const PROP_NAMESPACE    = 'namespace'
 const DEFAULT_NAMESPACE = 'couchdb'
+const SIGNAL_INTERRUPT  = 'SIGINT'
 
 
 const Plugin = PluginFactory(config => {
-  const namespace  = R.propOr(DEFAULT_NAMESPACE, 'namespace', config)
-  const couch_pool = CouchDBPool(config)
+  const namespace     = R.propOr(DEFAULT_NAMESPACE, PROP_NAMESPACE, config)
 
-  process.on('SIGINT', couch_pool.shutdown)
+  debug('CouchDB Plugin - server configuration - %o', config)
+  debug('CouchDB Plugin - namespace - %s', namespace)
+
+  const couch_pool    = CouchDBPool(config)
+
+  process.on(SIGNAL_INTERRUPT, couch_pool.shutdown)
 
   return (req, res, next) => {
 

--- a/lib/couchdb/index.js
+++ b/lib/couchdb/index.js
@@ -128,9 +128,9 @@ const findById = R.curry((couch, bucket, projection, id) => R.composeP(
 )(bucket, id))
 
 
-module.exports = ({ db_config }) =>
+module.exports = (server_config) =>
 
-  CouchWrapper(db_config)
+  CouchWrapper(server_config)
 
   .then((couch) => ({
     insert     : insert(couch)

--- a/lib/couchdb/pool.js
+++ b/lib/couchdb/pool.js
@@ -5,8 +5,6 @@ const Bluebird = require('bluebird')
 const Pool     = require('../pool.js')
 const CouchDB  = require('./index.js')
 
-const CONFIG_PROP = 'db_config'
-
 const DEFAULT_CONFIG = {
   url: 'http://localhost'
 , port: 5984
@@ -21,7 +19,6 @@ const factoryFactory = (config = {}) => ({
   create: R.compose(
     CouchDB
   , R.tap((cfg) => debug('couchdb configuration: %o', cfg))
-  , R.objOf(CONFIG_PROP)
   , R.always(config)
   )
 

--- a/test/lib/couchdb/index.spec.js
+++ b/test/lib/couchdb/index.spec.js
@@ -78,7 +78,7 @@ describe('lib/couchdb', function() {
 
   before(function() {
 
-    return Bluebird.resolve(CouchDB({ db_config: DB_CONN }))
+    return Bluebird.resolve(CouchDB(DB_CONN))
 
     .tap((client) => { couchdb = client })
   })


### PR DESCRIPTION
***BREAKING CHANGES***

### Couch Database Client Wrapper
The couch database client wrapper no longer expects the server
configuration to be wrapped in an object with the pertinent
configuration to be found at the `db_config` namespace.  You are now
expected to submit an object with all of the configuration parameters
(`url`, `port`, `username`, `password`) at the top level of the object.

```javascript
const CouchClient = require('kuss/lib/couchdb')
const config = {
  username: 'root'
, password: 'password'
}

const client = CouchClient(config)
```

### Couch Database Plugin
You will need to wrap your CouchDB server configuration into the
`server` property instead of the `db_config` property.

```javascript
// somewhere in your expressjs app
const CouchPlugin = require('kuss/express-couchdb')
const config = {
  namespace: 'my_couch'
, server: {
    username: 'root'
  , password: 'password'
  }
}

app.use(CouchPlugin(config))
```