### PR TITLE
Drop the Scheme in RabbitMQ's URL

### DIFF
--- a/lib/rabbitmq/pool.js
+++ b/lib/rabbitmq/pool.js
@@ -4,14 +4,14 @@ const Pool        = require('../pool.js')
 const amqplib     = require('amqplib')
 
 const DEFAULT_CONFIG = {
-  url: 'amqp://localhost'
+  url: 'localhost'
 , channelMax: 0
 , heartbeat: 0
 }
 
 
 const connect = R.converge(amqplib.connect, [
-  R.prop('url')
+  R.compose((url) => `amqp://${url}`, R.prop('url'))
 , R.pick(['channelMax', 'heartbeat'])
 ])
 


### PR DESCRIPTION
Only ask for the host, without the `amqp://` scheme. User doesn't need to know what rabbitmq driver kuss uses.