### PR TITLE
[#134408063]  Kuss standardize NotFound and TooManyRecords Errors

### DIFF
--- a/lib/couchdb/index.js
+++ b/lib/couchdb/index.js
@@ -13,11 +13,6 @@ const ONE             = 1
 const hasOnlyOne = R.compose(R.equals(ONE), R.length)
 
 
-const throwTooManyError = R.curry((bucket, prop, value, count) =>
-  Err.throwCussError(Err.TooManyRecords, bucket, prop, value, count)
-)
-
-
 const propValueToPredicate = R.compose(R.objOf('predicates'), R.objOf)
 
 
@@ -113,7 +108,7 @@ const findOneBy = R.curry((couch, bucket, projection, prop, value) =>
     R.ifElse(
       hasOnlyOne
     , R.head
-    , R.compose(throwTooManyError(bucket, prop, value), R.length)
+    , R.compose(Err.TooManyRecords.throw(STORE, bucket, prop, value), R.length)
     )
   , findWhereEq(couch, bucket)
   , wrapProjection(projection)

--- a/lib/couchdb/index.js
+++ b/lib/couchdb/index.js
@@ -5,6 +5,7 @@ const CouchWrapper = require('./wrapper.js')
 const ID           = require('../identifier.js')
 const Err          = require('../error.js')
 
+const STORE           = 'couchdb'
 const DEFAULT_OPTIONS = {}
 const ONE             = 1
 
@@ -25,6 +26,10 @@ const wrapProjection = R.compose(R.merge, R.objOf('projection'))
 
 const getById = R.curry((couch, bucket, id) =>
   Bluebird.resolve(couch.get(bucket, id))
+  .catch(e => {
+    if (e.statusCode != Err.STATUS.NOT_FOUND) throw e
+    return undefined
+  })
 )
 
 
@@ -65,14 +70,8 @@ const update = R.curry((couch, bucket, id, params) =>
     R.prop('id')
   , couch.create(bucket, id)
   , R.merge(R.__, params)
-  , R.tryCatch(
-      getById(couch, bucket)
-    , R.ifElse(
-        R.propEq(Err.STATUS.NOT_FOUND, 'status')
-      , Err.throwCussError.bind(null, Err.NotFound, bucket, id)
-      , (e) => { throw e }
-      )
-    )
+  , R.tap(R.when(R.isNil, () => Err.NotFound.throw(STORE, bucket, id)))
+  , getById(couch, bucket)
 )(id)))
 
 

--- a/lib/couchdb/index.js
+++ b/lib/couchdb/index.js
@@ -21,11 +21,7 @@ const wrapProjection = R.compose(R.merge, R.objOf('projection'))
 
 const getById = R.curry((couch, bucket, id) =>
   Bluebird.resolve(couch.get(bucket, id))
-  .catch(R.ifElse(
-    R.propEq('statusCode', Err.STATUS.NOT_FOUND)
-  , R.always(undefined)
-  , (e) => { throw e })
-  )
+  .catch({ statusCode : Err.STATUS.NOT_FOUND }, R.always(undefined))
 )
 
 

--- a/lib/couchdb/index.js
+++ b/lib/couchdb/index.js
@@ -21,10 +21,11 @@ const wrapProjection = R.compose(R.merge, R.objOf('projection'))
 
 const getById = R.curry((couch, bucket, id) =>
   Bluebird.resolve(couch.get(bucket, id))
-  .catch(e => {
-    if (e.statusCode != Err.STATUS.NOT_FOUND) throw e
-    return undefined
-  })
+  .catch(R.ifElse(
+    R.propEq('statusCode', Err.STATUS.NOT_FOUND)
+  , R.always(undefined)
+  , (e) => { throw e })
+  )
 )
 
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -2,7 +2,7 @@
 //eslint-disable-next-line max-len
 //@see http://stackoverflow.com/questions/31089801/extending-error-in-javascript-with-es6-syntax
 
-const { curry } = require('ramda')
+const R = require('ramda')
 
 const STATUS_CODE_ERROR     = 500
 const STATUS_CODE_NOT_FOUND = 404
@@ -30,7 +30,7 @@ class TooManyRecords extends CussError {
   }
 }
 
-TooManyRecords.throw = curry((store, table, field, constraint, count) => {
+TooManyRecords.throw = R.curry((store, table, field, constraint, count) => {
   throw new TooManyRecords(store, table, field, constraint, count)
 })
 
@@ -42,7 +42,7 @@ class NotFound extends CussError {
   }
 }
 
-NotFound.throw = curry((store, table, id) => {
+NotFound.throw = R.curry((store, table, id) => {
   throw new NotFound(store, table, id)
 })
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,8 +1,8 @@
 
-
 //eslint-disable-next-line max-len
 //@see http://stackoverflow.com/questions/31089801/extending-error-in-javascript-with-es6-syntax
 
+const { curry } = require('ramda')
 
 const STATUS_CODE_ERROR     = 500
 const STATUS_CODE_NOT_FOUND = 404
@@ -32,11 +32,15 @@ class TooManyRecords extends CussError {
 
 
 class NotFound extends CussError {
-  constructor(table, id) {
-    const message = `Not Found - TABLE: ${table} ID: ${id}`
+  constructor(store, table, id) {
+    const message = `Not Found - STORE: ${store} TABLE: ${table} ID: ${id}`
     super(message, STATUS_CODE_NOT_FOUND)
   }
 }
+
+NotFound.throw = curry((store, table, id) => {
+  throw new NotFound(store, table, id)
+})
 
 
 // Stack Overflow: Use of apply with new operator is this possible?

--- a/lib/error.js
+++ b/lib/error.js
@@ -47,13 +47,6 @@ NotFound.throw = curry((store, table, id) => {
 })
 
 
-// Stack Overflow: Use of apply with new operator is this possible?
-// https://goo.gl/DbW7po
-const throwCussError = (Type, ...args) => {
-  throw new (Type.bind(Type, ...args))()
-}
-
-
 module.exports = {
   STATUS: {
     ERROR: STATUS_CODE_ERROR
@@ -62,5 +55,4 @@ module.exports = {
 , CussError
 , TooManyRecords
 , NotFound
-, throwCussError
 }

--- a/lib/error.js
+++ b/lib/error.js
@@ -21,14 +21,18 @@ class CussError extends Error {
 
 
 class TooManyRecords extends CussError {
-  constructor(table, field, constraint, count) {
+  constructor(store, table, field, constraint, count) {
     const message = 'Too many records. '
-      + `Found ${count} records in \`${table}\` `
+      + `Found ${count} records in \`${store}\`.\`${table}\` `
       + `where \`${field}\` = "${constraint}"`
 
     super(message, STATUS_CODE_ERROR)
   }
 }
+
+TooManyRecords.throw = curry((store, table, field, constraint, count) => {
+  throw new TooManyRecords(store, table, field, constraint, count)
+})
 
 
 class NotFound extends CussError {

--- a/lib/memory/index.js
+++ b/lib/memory/index.js
@@ -5,18 +5,14 @@ const uuid     = require('uuid')
 const Err      = require('../error.js')
 const Util     = require('../util')
 
-const ZERO = 0
-const ONE  = 1
-const TWO  = 2
+const STORE = 'memory'
+const ZERO  = 0
+const ONE   = 1
+const TWO   = 2
 
 
 const throwInvalidBucket = (bucket) => {
   throw new Error(`Invalid Bucket: ${bucket}`)
-}
-
-
-const throwItemNotFound  = (bucket, id) => {
-  throw new Error(`Item ID#${id} Not Found in bucket: ${bucket}`)
 }
 
 
@@ -61,7 +57,7 @@ module.exports = function MemoryStore(data_set) {
 
     getById(bucket, id)
 
-    .tap(R.when(R.isNil, () => throwItemNotFound(bucket, id)))
+    .tap(R.when(R.isNil, () => Err.NotFound.throw(STORE, bucket, id)))
 
     .then(() => {
       store[bucket][id] = R.merge(store[bucket][id], data)

--- a/lib/memory/index.js
+++ b/lib/memory/index.js
@@ -160,15 +160,11 @@ module.exports = function MemoryStore(data_set) {
 
 
   const findOneBy = R.curry((bucket, projection, prop, value) =>
-      findBy(bucket, projection, prop, value)
-
-    .tap((results) => {
-      if (ONE < results.length)
-        throw new Err.TooManyRecords(
-          bucket, prop, value, results.length
-        )
-    })
-
+    findBy(bucket, projection, prop, value)
+    .tap(R.compose(
+      R.when(R.lt(ONE), Err.TooManyRecords.throw(STORE, bucket, prop, value))
+    , R.length
+    ))
     .then(R.head))
 
 

--- a/lib/mysql/index.js
+++ b/lib/mysql/index.js
@@ -6,6 +6,7 @@ const Err       = require('../error.js')
 const STORE        = 'mysql'
 const FIELD_ID     = 'id'
 const MIN_AFFECTED = 1
+const ONE          = 1
 
 
 const withoutId = R.omit([FIELD_ID])
@@ -37,8 +38,7 @@ const projectionToSql = (mysql, table, projection) => R.compose(
 
 
 const maxOneRecord = R.curry((table, field, value) => R.compose(
-  //eslint-disable-next-line no-magic-numbers
-  R.when(R.lt(1), Err.TooManyRecords.throw(STORE, table, field, value))
+  R.when(R.lt(ONE), Err.TooManyRecords.throw(STORE, table, field, value))
 , R.length
 ))
 

--- a/lib/mysql/index.js
+++ b/lib/mysql/index.js
@@ -36,11 +36,11 @@ const projectionToSql = (mysql, table, projection) => R.compose(
 )(projection)
 
 
-const maxOneRecord = (table, field, value) => (results) => {
+const maxOneRecord = R.curry((table, field, value) => R.compose(
   //eslint-disable-next-line no-magic-numbers
-  if (1 < results.length)
-    throw new Err.TooManyRecords(table, field, value, results.length)
-}
+  R.when(R.lt(1), Err.TooManyRecords.throw(STORE, table, field, value))
+, R.length
+))
 
 
 const selectAllFrom = (mysql, table) =>

--- a/lib/mysql/index.js
+++ b/lib/mysql/index.js
@@ -3,8 +3,9 @@ const R         = require('ramda')
 const { Query } = require('pimp-my-sql')
 const Err       = require('../error.js')
 
-
-const FIELD_ID  = 'id'
+const STORE        = 'mysql'
+const FIELD_ID     = 'id'
+const MIN_AFFECTED = 1
 
 
 const withoutId = R.omit([FIELD_ID])
@@ -50,7 +51,9 @@ const insert = Query.insert
 
 
 const update = R.curry((mysql, table, id, params) =>
-  Query.update(mysql, table, params, id).return(id)
+  Query.update(mysql, table, params, id)
+  .tap(R.when(R.gt(MIN_AFFECTED), () => Err.NotFound.throw(STORE, table, id)))
+  .return(id)
 )
 
 

--- a/test/lib/couchdb/index.spec.js
+++ b/test/lib/couchdb/index.spec.js
@@ -306,23 +306,15 @@ describe('lib/couchdb', function() {
 
       const PROJECTION = [ 'username' ]
       const expected   = 'Too many records. Found 2 records in ' +
-                         '`kuss-test-db` where `side` = "villain"'
+                         '`couchdb`.`kuss-test-db` where `side` = "villain"'
 
       return insertAllTestDocs(couchdb)
-
       .then(() => couchdb.findOneBy(DB_NAME, PROJECTION, 'side', 'villain'))
-
       .then(() => { throw new Error('Did not catch invalid response') })
-
-      .catch((e) => {
-
-        demand(e.name).eql('TooManyRecords')
-        demand(e.message).eql(expected)
-
-      })
+      .catch(Err.TooManyRecords, e => { demand(e.message).eql(expected) })
+      .catch(() => { throw new Error('should not get here noob') })
 
     })
-
 
   })
 

--- a/test/lib/error.js
+++ b/test/lib/error.js
@@ -14,16 +14,33 @@ describe('lib/error.js', function() {
 
     try {
 
-      Error.throwCussError(Error.NotFound, 'foo', 'bar')
+      Error.throwCussError(Error.NotFound, 'couch', 'foo', 'bar')
 
     } catch (e) {
 
-      demand(e.message).eql(`Not Found - TABLE: foo ID: bar`)
+      demand(e.name).eql('NotFound')
       demand(e.status).eql(404)
+      demand(e.message).eql(`Not Found - STORE: couch TABLE: foo ID: bar`)
 
     }
 
   })
 
+  it('NotFound Error should have a composable throw method',
+  function() {
+
+    try {
+
+      Error.NotFound.throw('couch')('foo')('bar')
+
+    } catch (e) {
+
+      demand(e.name).eql('NotFound')
+      demand(e.status).eql(404)
+      demand(e.message).eql(`Not Found - STORE: couch TABLE: foo ID: bar`)
+
+    }
+
+  })
 
 })

--- a/test/lib/error.js
+++ b/test/lib/error.js
@@ -43,4 +43,24 @@ describe('lib/error.js', function() {
 
   })
 
+  it('TooManyRecords Error should have a composable throw method',
+  function() {
+
+    try {
+
+      Error.TooManyRecords.throw('couch')('interest')('fave')('butts')(2)
+
+    } catch (e) {
+
+      const message = 'Too many records. '
+                    + 'Found 2 records in \`couch\`.\`interest\` '
+                    + 'where \`fave\` = "butts"'
+
+      demand(e.name).eql('TooManyRecords')
+      demand(e.status).eql(500)
+      demand(e.message).eql(message)
+    }
+
+  })
+
 })

--- a/test/lib/error.js
+++ b/test/lib/error.js
@@ -8,24 +8,6 @@ const Error  = require('../../lib/error.js')
 
 describe('lib/error.js', function() {
 
-
-  it('You should be able to throw a NotFound error',
-  function() {
-
-    try {
-
-      Error.throwCussError(Error.NotFound, 'couch', 'foo', 'bar')
-
-    } catch (e) {
-
-      demand(e.name).eql('NotFound')
-      demand(e.status).eql(404)
-      demand(e.message).eql(`Not Found - STORE: couch TABLE: foo ID: bar`)
-
-    }
-
-  })
-
   it('NotFound Error should have a composable throw method',
   function() {
 

--- a/test/lib/memory.spec.js
+++ b/test/lib/memory.spec.js
@@ -5,6 +5,7 @@
 const R           = require('ramda')
 const { expect }  = require('chai')
 const MemoryStore = require('../../lib/memory')
+const Err         = require('../../lib/error')
 
 
 describe('lib/memory-store.js', function() {
@@ -37,6 +38,19 @@ describe('lib/memory-store.js', function() {
         expect(result.foo).to.eql(data.foo)
         expect(result.boo).to.eql('hoo')
       })
+    })
+
+    it(`should throw a NotFound error if you try to update a non-existant
+      document`, () => {
+
+      const bucket    = 'test'
+      const data      = { id : '1', foo: 'bar', boo: 'fuck' }
+      const state     = { [bucket] : {} }
+      const tempStore = MemoryStore(state)
+
+      return tempStore.update(bucket, data.id, { boo : 'hoo' })
+      .then(() => { throw new Error('should not have gotten here, noob') })
+      .catch(Err.NotFound, e => { expect(e.status).eql(404) })
     })
   })
 

--- a/test/lib/memory.spec.js
+++ b/test/lib/memory.spec.js
@@ -216,20 +216,16 @@ describe('lib/memory-store.js', function() {
       const proj = [ 'bar_key' ]
 
       return store.insert(bucket, data1)
-        .then(() => store.insert(bucket, data2))
-
-        .then(() => store.findOneBy(bucket, proj, 'bar_key', 'blah'))
-
-        .then((x) => {
-
-          x.must.be.an.object()
-          x.must.include('blah')
-
-        })
+      .then(() => store.insert(bucket, data2))
+      .then(() => store.findOneBy(bucket, proj, 'bar_key', 'blah'))
+      .then((x) => {
+        x.must.be.an.object()
+        x.must.include('blah')
+      })
 
     })
 
-    it('should return an error if it returns more than one obj', function() {
+    it('should throw TooManyRecords if it returns more than one obj', () => {
 
       const bucket = 'test'
       const data1 = { foo: 'random', bar_key: 'blah' }
@@ -238,21 +234,11 @@ describe('lib/memory-store.js', function() {
       const proj = [ 'bar_key' ]
 
       return store.insert(bucket, data1)
-        .then(() => store.insert(bucket, data2))
-        .then(() => store.insert(bucket, data3))
-
-        .then(() => store.findOneBy(bucket, proj, 'bar_key', 'derp'))
-
-        .then((x) => {
-
-          console.log(x)
-
-        })
-        .catch((e) => {
-
-          (e.name).must.eql('TooManyRecords')
-
-        })
+      .then(() => store.insert(bucket, data2))
+      .then(() => store.insert(bucket, data3))
+      .then(() => store.findOneBy(bucket, proj, 'bar_key', 'derp'))
+      .then(() => { throw new Error('should not get here noob!') })
+      .catch(Err.TooManyRecords, e => { (e.status).must.eql(500) })
 
     })
 

--- a/test/lib/mysql/index.spec.js
+++ b/test/lib/mysql/index.spec.js
@@ -468,9 +468,7 @@ describe('lib/mysql', function() {
       })
 
 
-    it('should throw an error if the query returns more than one item',
-      function() {
-
+    it('should throw an error if the query returns more than one item', () => {
         const table        = 'test'
         const projection   = [ 'foo' , 'bar' ]
         const params       = [ 'run away, run away' ]
@@ -478,33 +476,24 @@ describe('lib/mysql', function() {
           + ' FROM `test`'
           + ' WHERE `foo` = ? '
 
-
         mysql.query = (actual_sql, actual_params, cb) => {
-
           expect(actual_sql).to.eql(expected_sql)
           expect(actual_params).to.deep.eql(params)
-
           cb(null, [ { test: 'pass' }, { test: 'fail' } ])
         }
 
         return store.findOneBy(table, projection, projection[0], params[0])
-
-          .then(() => { throw new Error('Unexpected success') })
-
-          .catch((e) => {
-            if (e.name === 'AssertionError') throw e
-
-            expect(e.name).to.eql('TooManyRecords')
-            expect(e.message).to.eql(
-              'Too many records. ' +
-              'Found 2 records in `test` ' +
-              'where `foo` = "run away, run away"'
-            )
-
-          })
+        .then(() => { throw new Error('Unexpected success') })
+        .catch(Err.TooManyRecords, e => {
+          expect(e.status).eql(500)
+          expect(e.message).to.eql(
+            'Too many records. ' +
+            'Found 2 records in `mysql`.`test` ' +
+            'where `foo` = "run away, run away"'
+          )
+        })
 
       })
-
 
   })
 


### PR DESCRIPTION
- Fix findOneBy in all drivers to return/throw same values
- Fix getById in all drivers to return/throw same values
- Add throw method to TooManyRecords and NotFound Errors
- Fix unit tests broken by changes