### PR TITLE
Faster Couch bulk_upsert

### DIFF
--- a/lib/couchdb/index.js
+++ b/lib/couchdb/index.js
@@ -1,9 +1,10 @@
 
-const R              = require('ramda')
-const Bluebird       = require('bluebird')
-const CouchWrapper   = require('./wrapper.js')
-const ID             = require('../identifier.js')
-const Err            = require('../error.js')
+const R            = require('ramda')
+const Bluebird     = require('bluebird')
+const CouchWrapper = require('./wrapper.js')
+const ID           = require('../identifier.js')
+const Err          = require('../error.js')
+const Util         = require('../util')
 
 const STORE           = 'couchdb'
 const DEFAULT_OPTIONS = {}
@@ -84,6 +85,34 @@ const upsert = R.curry((couch, bucket, keys, doc) =>
 )(doc)))
 
 
+const _findWhereEqById = R.curry((couch, bucket, predicates) =>
+  Bluebird.resolve({})
+  .then(() => getById(couch, bucket, predicates.id))
+  .then(R.when(Util.notNil, (doc) => R.compose(
+    R.ifElse(
+      R.equals(ID.couchify(predicates))
+    , R.always([doc])
+    , R.always(null)
+    )
+  , R.pick(R.keys(ID.couchify(predicates)))
+  )(doc)))
+)
+
+
+const _findWhereEqOrGetById = R.curry((couch, bucket, predicates) =>
+  Bluebird.resolve(predicates)
+  .then(R.ifElse(
+    R.has('id')
+  , _findWhereEqById(couch, bucket)
+  , (preds) => findWhereEq(
+      couch
+    , bucket
+    , R.objOf('predicates', ID.couchify(preds))
+    )
+  ))
+)
+
+
 const bulk_upsert = R.curry((couch, bucket, keys, docs) =>
   Bluebird.map(docs, (doc) =>
     Bluebird.resolve(keys)
@@ -91,16 +120,12 @@ const bulk_upsert = R.curry((couch, bucket, keys, docs) =>
     .then(R.ifElse(
       R.isEmpty
     , R.always(doc)
-    , (predicates) => findWhereEq(
-        couch
-      , bucket
-      , R.objOf('predicates', ID.couchify(predicates))
-      )
+    , _findWhereEqOrGetById(couch, bucket)
     ))
     .then(R.ifElse(
-      R.isEmpty
+      Util.isEmptyOrNil
     , R.always(ID.couchify(doc))
-    , R.compose(ID.couchify, R.merge(R.__, doc), R.head)
+    , R.compose(R.merge(R.__, ID.couchify(doc)), R.head)
     ))
   )
   .then(couch.bulk_upsert(bucket))
@@ -170,3 +195,4 @@ module.exports = (server_config) =>
   , findById   : findById(couch)
   , findWhereEq: findWhereEq(couch)
   }))
+

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -44,10 +44,18 @@ const replaceElement = R.curry((from, to, list) => R.when(
 )(list))
 
 
+const notNil = R.compose(R.not, R.isNil)
+
+
+const isEmptyOrNil = R.either(R.isEmpty, R.isNil)
+
+
 module.exports = {
   ascend
 , descend
 , sortWhere
 , renameProp
 , replaceElement
+, notNil
+, isEmptyOrNil
 }


### PR DESCRIPTION
It was relying on findWhereEq and it was painfully slow. It now uses
getById for faster doc retrieval if id field is provided, otherwise it
falls back to using findWhereEq.