### PR TITLE
Faster Couch bulk_upsert

### DIFF
--- a/lib/couchdb/index.js
+++ b/lib/couchdb/index.js
@@ -112,7 +112,7 @@ const _findOneWhereEq = R.curry((couch, bucket, predicates) =>
 )
 
 
-const findOneEq = R.curry((couch, bucket, predicates) =>
+const findOneWhereEq = R.curry((couch, bucket, predicates) =>
   Bluebird.resolve(predicates)
   .then(R.ifElse(
     R.has('id')
@@ -129,7 +129,7 @@ const bulk_upsert = R.curry((couch, bucket, keys, docs) =>
     .then(R.ifElse(
       R.isEmpty
     , R.always(doc)
-    , findOneEq(couch, bucket)
+    , findOneWhereEq(couch, bucket)
     ))
     .then(R.ifElse(
       Util.isEmptyOrNil

--- a/lib/couchdb/index.js
+++ b/lib/couchdb/index.js
@@ -85,8 +85,8 @@ const upsert = R.curry((couch, bucket, keys, doc) =>
 )(doc)))
 
 
-const _findOneEqById = R.curry((couch, bucket, predicates) =>
-  getById(couch, bucket, predicates.id)
+const _findOneByIdWhereEq = R.curry((couch, bucket, id, predicates) =>
+  getById(couch, bucket, id)
   .then(R.when(Util.notNil, (doc) => R.compose(
     R.ifElse(
       R.equals(ID.couchify(predicates))
@@ -98,7 +98,7 @@ const _findOneEqById = R.curry((couch, bucket, predicates) =>
 )
 
 
-const _findOneEq = R.curry((couch, bucket, predicates) =>
+const _findOneWhereEq = R.curry((couch, bucket, predicates) =>
   findWhereEq(
     couch
   , bucket
@@ -116,8 +116,8 @@ const findOneEq = R.curry((couch, bucket, predicates) =>
   Bluebird.resolve(predicates)
   .then(R.ifElse(
     R.has('id')
-  , _findOneEqById(couch, bucket)
-  , _findOneEq(couch, bucket)
+  , _findOneByIdWhereEq(couch, bucket, predicates.id)
+  , _findOneWhereEq(couch, bucket)
   ))
 )
 

--- a/lib/couchdb/index.js
+++ b/lib/couchdb/index.js
@@ -87,14 +87,17 @@ const upsert = R.curry((couch, bucket, keys, doc) =>
 
 const _findOneByIdWhereEq = R.curry((couch, bucket, id, predicates) =>
   getById(couch, bucket, id)
-  .then(R.when(Util.notNil, (doc) => R.compose(
-    R.ifElse(
-      R.equals(ID.couchify(predicates))
-    , R.always(doc)
-    , R.always(null)
-    )
-  , R.pick(R.keys(ID.couchify(predicates)))
-  )(doc)))
+  .then(R.when(
+    Util.notNil
+  , (doc) => R.compose(
+      R.ifElse(
+        R.equals(ID.couchify(predicates))
+      , R.always(doc)
+      , R.always(null)
+      )
+    , R.pick(R.keys(ID.couchify(predicates)))
+    )(doc)
+  ))
 )
 
 

--- a/lib/couchdb/index.js
+++ b/lib/couchdb/index.js
@@ -87,16 +87,9 @@ const upsert = R.curry((couch, bucket, keys, doc) =>
 
 const _findOneByIdWhereEq = R.curry((couch, bucket, id, predicates) =>
   getById(couch, bucket, id)
-  .then(R.when(
-    Util.notNil
-  , (doc) => R.compose(
-      R.ifElse(
-        R.equals(ID.couchify(predicates))
-      , R.always(doc)
-      , R.always(null)
-      )
-    , R.pick(R.keys(ID.couchify(predicates)))
-    )(doc)
+  .then(R.unless(
+    R.allPass([Util.notNil, R.whereEq(ID.couchify(predicates))])
+  , R.always(null)
   ))
 )
 

--- a/lib/couchdb/index.js
+++ b/lib/couchdb/index.js
@@ -1,9 +1,10 @@
 
-const R              = require('ramda')
-const Bluebird       = require('bluebird')
-const CouchWrapper   = require('./wrapper.js')
-const ID             = require('../identifier.js')
-const Err            = require('../error.js')
+const R            = require('ramda')
+const Bluebird     = require('bluebird')
+const CouchWrapper = require('./wrapper.js')
+const ID           = require('../identifier.js')
+const Err          = require('../error.js')
+const Util         = require('../util')
 
 const STORE           = 'couchdb'
 const DEFAULT_OPTIONS = {}
@@ -84,6 +85,43 @@ const upsert = R.curry((couch, bucket, keys, doc) =>
 )(doc)))
 
 
+const _findOneEqById = R.curry((couch, bucket, predicates) =>
+  getById(couch, bucket, predicates.id)
+  .then(R.when(Util.notNil, (doc) => R.compose(
+    R.ifElse(
+      R.equals(ID.couchify(predicates))
+    , R.always(doc)
+    , R.always(null)
+    )
+  , R.pick(R.keys(ID.couchify(predicates)))
+  )(doc)))
+)
+
+
+const _findOneEq = R.curry((couch, bucket, predicates) =>
+  findWhereEq(
+    couch
+  , bucket
+  , R.objOf('predicates', ID.couchify(predicates))
+  )
+  .then(R.ifElse(
+    hasOnlyOne
+  , R.head
+  , R.compose(Err.TooManyRecords.throw(STORE, bucket, predicates), R.length)
+  ))
+)
+
+
+const findOneEq = R.curry((couch, bucket, predicates) =>
+  Bluebird.resolve(predicates)
+  .then(R.ifElse(
+    R.has('id')
+  , _findOneEqById(couch, bucket)
+  , _findOneEq(couch, bucket)
+  ))
+)
+
+
 const bulk_upsert = R.curry((couch, bucket, keys, docs) =>
   Bluebird.map(docs, (doc) =>
     Bluebird.resolve(keys)
@@ -91,16 +129,12 @@ const bulk_upsert = R.curry((couch, bucket, keys, docs) =>
     .then(R.ifElse(
       R.isEmpty
     , R.always(doc)
-    , (predicates) => findWhereEq(
-        couch
-      , bucket
-      , R.objOf('predicates', ID.couchify(predicates))
-      )
+    , findOneEq(couch, bucket)
     ))
     .then(R.ifElse(
-      R.isEmpty
+      Util.isEmptyOrNil
     , R.always(ID.couchify(doc))
-    , R.compose(ID.couchify, R.merge(R.__, doc), R.head)
+    , R.merge(R.__, ID.couchify(doc))
     ))
   )
   .then(couch.bulk_upsert(bucket))
@@ -170,3 +204,4 @@ module.exports = (server_config) =>
   , findById   : findById(couch)
   , findWhereEq: findWhereEq(couch)
   }))
+

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -44,10 +44,18 @@ const replaceElement = R.curry((from, to, list) => R.when(
 )(list))
 
 
+const notNil = R.compose(R.not, R.isNil)
+
+
+const isEmptyOrNil = R.either(R.isEmpty, R.isNil)
+
+
 module.exports = {
   ascend
 , descend
 , sortWhere
 , renameProp
 , replaceElement
+, notNil
+, isEmptyOrNil
 }

--- a/test/lib/couchdb/index.spec.js
+++ b/test/lib/couchdb/index.spec.js
@@ -195,7 +195,7 @@ describe('lib/couchdb', function() {
   describe('::bulk_upsert', function() {
 
     it(`should update a list of documents in the given bucket based on the
-       _id and _rev keys. if these two keys don't exist, create the document
+       _id and _rev keys. If these two keys don't exist, create the document
        in the bucket`, function() {
 
       return couchdb.insert(DB_NAME, { id: '1', first: 'mat', last: 'chuang' })
@@ -214,6 +214,31 @@ describe('lib/couchdb', function() {
         demand(res.rows).have.length(2)
         demand(map['1'].first).equal('matt')
         demand(map['2'].first).equal('jon')
+      })
+
+    })
+
+
+    it(`should update a list of documents in the given bucket based on the
+       _id and _rev keys. If these two keys don't exist, create the document
+       in the bucket`, function() {
+
+      return couchdb.insert(DB_NAME, { id: '1', first: 'mat', last: 'chuang' })
+      .then(() => couchdb.bulk_upsert(DB_NAME, ['last'], [
+        { first: 'matt', last: 'chuang' }
+      , { first: 'jon', last: 'lee' }
+      ]))
+      .then(() => couchdb.getAll(DB_NAME))
+      .then((res) => {
+
+        const map = R.compose(
+          R.mergeAll
+        , R.map((row) => ({ [row.doc.last] : row.doc }))
+        )(res.rows)
+
+        demand(res.rows).have.length(2)
+        demand(map['chuang'].first).equal('matt')
+        demand(map['lee'].first).equal('jon')
       })
 
     })


### PR DESCRIPTION
It was relying on findWhereEq and it was painfully slow. It now uses
getById for faster doc retrieval if id field is provided, otherwise it
falls back to using findWhereEq.