### PR TITLE
Fixes Broken Upsert

### DIFF
--- a/lib/couchdb/index.js
+++ b/lib/couchdb/index.js
@@ -68,20 +68,27 @@ const update = R.curry((couch, bucket, id, params) =>
 )(id)))
 
 
+// The keys array is an array of property names. Internally, this function
+// tries to find documents with selected key-value pairs as given document.
+// Then it updates the first document from found list, or insert a new
+// document.
+// :: CouchConnection -> String -> Array<String> -> Document
 const upsert = R.curry((couch, bucket, keys, doc) =>
-  Bluebird.resolve(R.composeP(
-    insert(couch, bucket)
-  , R.ifElse(
-      R.isEmpty
-    , R.always(doc)
-    , R.compose(R.merge(R.__, doc), ID.prop, R.head)
-    )
-  , R.compose(
-      findWhereEq(couch, bucket)
-    , R.objOf('predicates')
-    , R.pickAll(keys)
+  Bluebird.resolve(
+    R.composeP(
+      R.ifElse(
+        R.isEmpty
+      , () => insert(couch, bucket, doc)
+      , R.compose(update(couch, bucket, R.__, doc), R.prop('_id'), R.head)
+      )
+    , R.compose(
+        findWhereEq(couch, bucket)
+      , R.objOf('predicates')
+      , R.pickAll(keys)
+      )
+    )(doc)
   )
-)(doc)))
+)
 
 
 const bulk_upsert = R.curry((couch, bucket, keys, docs) =>


### PR DESCRIPTION
resolve #49    

- Fixes CouchDb upsert function. There were two issues with this  function:  the upsert function would always try to insert. Also it would take an 'id' property from a found document and merge it to the update document. But CouchDb doesn't have 'id', it has '_id'.